### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-basic-ssl",
   "version": "1.2.3",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-basic-ssl",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-basic-ssl#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-basic-ssl/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add the package README homepage URL to npm metadata
- add the GitHub issues URL as package `bugs` metadata

## Validation
- `node -e "const p=require('./package.json'); if(p.homepage !== 'https://github.com/rstackjs/rsbuild-plugin-basic-ssl#readme') throw new Error('bad homepage'); if(!p.bugs || p.bugs.url !== 'https://github.com/rstackjs/rsbuild-plugin-basic-ssl/issues') throw new Error('bad bugs url'); console.log(JSON.stringify({homepage:p.homepage, bugs:p.bugs}, null, 2));"`
- `npm view @rsbuild/plugin-basic-ssl@latest name version repository.url homepage bugs license --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`